### PR TITLE
[FIX] switch zeit now to Vercel Now for prisma docs

### DIFF
--- a/content/04-guides/02-deployment/01-deploying-to-vercel-now.mdx
+++ b/content/04-guides/02-deployment/01-deploying-to-vercel-now.mdx
@@ -1,14 +1,14 @@
 ---
-title: 'Deploying to ZEIT Now'
-metaTitle: 'Deploying to ZEIT Now'
-metaDescription: 'Learn how to deploy Node.js and TypeScript that are using Prisma Client to ZEIT Now.'
+title: 'Deploying to Vercel Now'
+metaTitle: 'Deploying to Vercel Now'
+metaDescription: 'Learn how to deploy Node.js and TypeScript that are using Prisma Client to Vercel Now.'
 ---
 
 ## Overview
 
-In this guide, you will set up and deploy a serverless Node.js application to [ZEIT Now](https://zeit.co/home). The application will expose a REST API and use Prisma Client to handle fetching, creating, and deleting records from a database.
+In this guide, you will set up and deploy a serverless Node.js application to [Vercel Now](https://vercel.com/home). The application will expose a REST API and use Prisma Client to handle fetching, creating, and deleting records from a database.
 
-ZEIT Now is a cloud platform for static sites and serverless functions. Typically Now integrates with a Git repository for automatic deployments upon commits. For the sake of simplicity, this guide uses the Now CLI which allows deploying directly from the command line.
+Vercel Now is a cloud platform for static sites and serverless functions. Typically Now integrates with a Git repository for automatic deployments upon commits. For the sake of simplicity, this guide uses the Now CLI which allows deploying directly from the command line.
 
 The application has the following components:
 
@@ -17,15 +17,15 @@ The application has the following components:
 
 ![architecture diagram](https://imgur.com/cR9V9v7.png)
 
-The focus of this guide is showing how Prisma integrates with ZEIT Now. The starting point will the [Prisma ZEIT Now example](https://github.com/prisma/prisma-examples/tree/master/deployment-platforms/zeit-now) which has a couple of REST endpoints preconfigured as serverless functions and a static page.
+The focus of this guide is showing how Prisma integrates with Vercel Now. The starting point will the [Prisma Vercel Now example](https://github.com/prisma/prisma-examples/tree/master/deployment-platforms/vercel-now) which has a couple of REST endpoints preconfigured as serverless functions and a static page.
 
 > Throughout the guide you'll find various **checkpoints** that enable you to validate whether you performed the steps correctly.
 
 ## Prerequisites
 
 - Hosted PostgreSQL database and a URL from which it can be accessed, e.g. `postgresql://username:password@your_postgres_db.cloud.com/db_identifier` (you can use Heroku, which offers a [free plan](https://dev.to/prisma/how-to-setup-a-free-postgresql-database-on-heroku-1dc1)).
-- [ZEIT Now](https://zeit.co) account.
-- [Now CLI](https://zeit.co/download) installed.
+- [Vercel Now](https://vercel.com) account.
+- [Now CLI](https://vercel.com/download) installed.
 - Node.js installed.
 - PostgreSQL CLI `psql` installed.
 
@@ -44,9 +44,9 @@ This guide starts with an empty database created with plain SQL and looks as fol
 Open your terminal and navigate to a location of your choice. Create the directory that will hold the application code and download the example code:
 
 ```sh
-mkdir prisma-zeit-now
-cd prisma-zeit-now
-curl https://codeload.github.com/prisma/prisma-examples/tar.gz/master | tar -xz --strip=3 prisma-examples-master/deployment-platforms/zeit-now/
+mkdir prisma-vercel-now
+cd prisma-vercel-now
+curl https://codeload.github.com/prisma/prisma-examples/tar.gz/master | tar -xz --strip=3 prisma-examples-master/deployment-platforms/vercel-now/
 ```
 
 <!-- tar strip folder is a concatenation of the REPOSITORY-BRANCH/REF, e.g. prisma-examples-master -->
@@ -70,15 +70,15 @@ Install the dependencies:
 npm install
 ```
 
-## 2. ZEIT Now login
+## 2. Vercel Now login
 
-Make sure you're logged in to ZEIT Now with the CLI:
+Make sure you're logged in to Vercel Now with the CLI:
 
 ```sh
 now login
 ```
 
-This will allow you to deploy to ZEIT Now from the terminal.
+This will allow you to deploy to Vercel Now from the terminal.
 
 **Checkpoint:** `now whoami` should show your username:
 
@@ -141,7 +141,7 @@ In step 4 you set the `DATABASE_URL` environment variable on your machine. For t
 
 Adding environment variables to Now requires two steps:
 
-1. Defining a [Now secret](https://zeit.co/docs/v2/build-step#using-environment-variables-and-secrets) via the Now CLI with `now secrets add`.
+1. Defining a [Now secret](https://vercel.com/docs/v2/build-step#using-environment-variables-and-secrets) via the Now CLI with `now secrets add`.
 2. Exposing the secret to your serverless functions in your `now.json` file.
 
 ```sh
@@ -209,7 +209,7 @@ For example, calling seed data should show the following:
 ## Notes
 
 The `package.json` uses the `postinstall` hook script to run `prisma generate`.
-Typically this would go in the `build` step. Because Zeit Now caches `node_modules` after the dependencies are installed, the functions won't have access to the generated Prisma Client.
+Typically this would go in the `build` step. Because Vercel Now caches `node_modules` after the dependencies are installed, the functions won't have access to the generated Prisma Client.
 Generating the Prisma Client in `postinstall` ensures that the generated Prisma Client in `node_modules/@prisma/client` is available to the functions.
 
 ## Summary


### PR DESCRIPTION
- Zeit just rebranded to Vercel and this PR changes the deployment guidelines to deployment
- Now still remains Now but ZEIT is no longer zeit but Vercel as of today